### PR TITLE
Jag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ username: <serial number of Hub>
 password: <Password as used in App>
 ```
 
-Additionally, to use the Leaf integrarion the you need the Nissan credentials, as well as the location of a local checkout of https://github.com/filcole/pycarwings2.git
+Additionally, to use the Leaf integration the you need the Nissan credentials, as well as the location of a local checkout of https://github.com/filcole/pycarwings2.git
 ```
 leaf:
     username: <email@example.com>
@@ -25,6 +25,12 @@ leaf:
     region: <NE>
 pycarwings_path: </path/to/pycarwings2>
 ```
+
+To use the Jaguar Land Rover integration the you need to pip install jlrpy and set config file with permissions. Config includes a max SOC - set to 100 if you wish to control max SOC from this application (https://github.com/ardevd/jlrpy.git)
+```
+jlr:
+    username: <email@example.com>
+    password: <Password for JLR Incontrol app>
 
 If using the Octopus Agile features it's necessary to set the region
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ username: <serial number of Hub>
 password: <Password as used in App>
 ```
 
-Additionally, to use the Leaf integrarion the you need the Nissan credentials, as well as the location of a local checkout of https://github.com/filcole/pycarwings2.git
+To use the Jaguar Land Rover integration the you need to pip install jlrpy and set config file with permissions. Config includes a max SOC - set to 100 if you wish to control max SOC from this application (https://github.com/ardevd/jlrpy.git)
+```
+jlr:
+    username: <email@example.com>
+    password: <Password for JLR Incontrol app>
+
+Additionally, to use the Leaf integration the you need the Nissan credentials, as well as the location of a local checkout of https://github.com/filcole/pycarwings2.git
 ```
 leaf:
     username: <email@example.com>
@@ -32,7 +38,7 @@ agile:
     region: H
 ```
 
-Finally, it's possible to apply some manual configuration to the CT clams on individual devices, for example if they are configured as 'Monitor' or 'AC Storage'.  In this way I am able to have mine report figures for my iBoost although it's seen by the Zappi as a AC Battery.
+Finally, it's possible to apply some manual configuration to the CT clamps on individual devices, for example if they are configured as 'Monitor' or 'AC Storage'.  In this way I am able to have mine report figures for my iBoost although it's seen by the Zappi as a AC Battery.
 ```
 house_data:
     <Zaapi serial number>:

--- a/README.md
+++ b/README.md
@@ -17,13 +17,7 @@ username: <serial number of Hub>
 password: <Password as used in App>
 ```
 
-To use the Jaguar Land Rover integration the you need to pip install jlrpy and set config file with permissions. Config includes a max SOC - set to 100 if you wish to control max SOC from this application (https://github.com/ardevd/jlrpy.git)
-```
-jlr:
-    username: <email@example.com>
-    password: <Password for JLR Incontrol app>
-
-Additionally, to use the Leaf integration the you need the Nissan credentials, as well as the location of a local checkout of https://github.com/filcole/pycarwings2.git
+Additionally, to use the Leaf integrarion the you need the Nissan credentials, as well as the location of a local checkout of https://github.com/filcole/pycarwings2.git
 ```
 leaf:
     username: <email@example.com>
@@ -38,7 +32,7 @@ agile:
     region: H
 ```
 
-Finally, it's possible to apply some manual configuration to the CT clamps on individual devices, for example if they are configured as 'Monitor' or 'AC Storage'.  In this way I am able to have mine report figures for my iBoost although it's seen by the Zappi as a AC Battery.
+Finally, it's possible to apply some manual configuration to the CT clams on individual devices, for example if they are configured as 'Monitor' or 'AC Storage'.  In this way I am able to have mine report figures for my iBoost although it's seen by the Zappi as a AC Battery.
 ```
 house_data:
     <Zaapi serial number>:

--- a/mec/session.py
+++ b/mec/session.py
@@ -65,6 +65,7 @@ class SessionEngine():
         self._conf = conf
         self._py2 = None
         self._mt = None
+        self._jlr = None
         if 'leaf' in conf:
 
             if 'pycarwings_path' in conf:
@@ -73,8 +74,11 @@ class SessionEngine():
                 self._py2 = __import__('pycarwings2')
             except ModuleNotFoundError:
                 self._py2 = None
-        elif 'tesla' in conf:
+        if 'tesla' in conf:
             self._mt = __import__('myTesla')
+
+        if 'jlr' in conf:
+            self._jlr = __import__('jlrpy')
 
     def new_session(self, have_car=False):
         """Return a new session"""
@@ -87,6 +91,8 @@ class SessionEngine():
                 return NullSession()
         elif self._mt:
             return TeslaSession(self._conf, self._mt)
+        elif self._jlr:
+            return jlrSession(self._conf, self._jlr)
         else:
             return NullSession()
 
@@ -349,3 +355,72 @@ class LeafSession(CommonSession):
             self.log.info('Total charge held %.2f', self._soc_kwh)
             self.log.info('SOC percentage %.0f', self.percent_charge())
 
+class jlrSession(CommonSession):
+    """Session counter"""
+
+    # Estimate of battery capacity, in terms of KwH charge to
+    # go from 0-100%.  Used for SOC calculations.
+    capacity = 85
+    charge_rate = 7800
+
+    def __init__(self, conf, jlr):
+        super().__init__(conf['jlr'])
+        jlr_conf = conf['jlr']
+
+        self._jlr = jlr.Connection(jlr_conf['username'], jlr_conf['password']).vehicles[0]
+        self._base_kwh = None
+
+
+    def _get_soc(self):
+        if not self._jlr:
+            return
+        raw = self._jlr.get_health_status()
+        self.log.debug(raw)
+        if 'Exception' in raw:
+            return
+        self._is_valid = True
+        current_soc = int(self._jlr.get_status('EV_STATE_OF_CHARGE'))
+        return current_soc
+
+    def _do_refresh(self):
+
+        new_percent = self._get_soc()
+
+        self.log.info('State of charge update %d%% %d%%',
+                      self.percent_charge(),
+                      new_percent)
+        # Calculate the observed capacity
+        added_percent = new_percent - self._initial_percent
+        added_kwh = self._soc_kwh - self._base_kwh
+        self.log.info('Percent %d %d %d', added_percent, new_percent, self._initial_percent)
+
+        if added_percent == 0:
+            return
+
+        new_cap = added_kwh * (100 / added_percent)
+        self.log.info('Capacity change from %.1f to %.1f after %.1f kwh',
+                      self.capacity,
+                      new_cap,
+                      added_kwh)
+
+    def update(self, kwh):
+
+        if self._is_valid is False:
+            return
+
+        if not self._base_kwh:
+            percent = self._get_soc()
+            if not percent:
+                return
+            self._initial_percent = percent
+            self._base_kwh = (self.capacity * self._initial_percent / 100) - kwh
+
+        self._soc_kwh = self._base_kwh + kwh
+
+        if self._refresh:
+            self._do_refresh()
+
+        if self.check_connected:
+            self.log.info('Total charge added %.2f', kwh)
+            self.log.info('Total charge held %.2f', self._soc_kwh)
+            self.log.info('SOC percentage %.0f', self.percent_charge())

--- a/mec/session.py
+++ b/mec/session.py
@@ -65,18 +65,16 @@ class SessionEngine():
         self._conf = conf
         self._py2 = None
         self._mt = None
-        self._jlr = None
         if 'leaf' in conf:
+
             if 'pycarwings_path' in conf:
                 sys.path.append(conf['pycarwings_path'])
             try:
                 self._py2 = __import__('pycarwings2')
             except ModuleNotFoundError:
                 self._py2 = None
-        if 'tesla' in conf:
+        elif 'tesla' in conf:
             self._mt = __import__('myTesla')
-        if 'jlr' in conf:
-            self._jlr = __import__('jlrpy')
 
     def new_session(self, have_car=False):
         """Return a new session"""
@@ -89,8 +87,6 @@ class SessionEngine():
                 return NullSession()
         elif self._mt:
             return TeslaSession(self._conf, self._mt)
-        elif self._jlr:
-            return jlrSession(self._conf, self._jlr)
         else:
             return NullSession()
 
@@ -353,72 +349,3 @@ class LeafSession(CommonSession):
             self.log.info('Total charge held %.2f', self._soc_kwh)
             self.log.info('SOC percentage %.0f', self.percent_charge())
 
-class jlrSession(CommonSession):
-    """Session counter"""
-
-    # Estimate of battery capacity, in terms of KwH charge to
-    # go from 0-100%.  Used for SOC calculations.
-    capacity = 85
-    charge_rate = 7800
-
-    def __init__(self, conf, jlr):
-        super().__init__(conf['jlr'])
-        jlr_conf = conf['jlr']
-
-        self._jlr = jlr.Connection(jlr_conf['username'], jlr_conf['password']).vehicles[0]
-        self._base_kwh = None
-
-
-    def _get_soc(self):
-        if not self._jlr:
-            return
-        raw = self._jlr.get_health_status()
-        self.log.debug(raw)
-        if 'Exception' in raw:
-            return
-        self._is_valid = True
-        current_soc = int(self._jlr.get_status('EV_STATE_OF_CHARGE'))
-        return current_soc
-
-    def _do_refresh(self):
-
-        new_percent = self._get_soc()
-
-        self.log.info('State of charge update %d%% %d%%',
-                      self.percent_charge(),
-                      new_percent)
-        # Calculate the observed capacity
-        added_percent = new_percent - self._initial_percent
-        added_kwh = self._soc_kwh - self._base_kwh
-        self.log.info('Percent %d %d %d', added_percent, new_percent, self._initial_percent)
-
-        if added_percent == 0:
-            return
-
-        new_cap = added_kwh * (100 / added_percent)
-        self.log.info('Capacity change from %.1f to %.1f after %.1f kwh',
-                      self.capacity,
-                      new_cap,
-                      added_kwh)
-
-    def update(self, kwh):
-
-        if self._is_valid is False:
-            return
-
-        if not self._base_kwh:
-            percent = self._get_soc()
-            if not percent:
-                return
-            self._initial_percent = percent
-            self._base_kwh = (self.capacity * self._initial_percent / 100) - kwh
-
-        self._soc_kwh = self._base_kwh + kwh
-
-        if self._refresh:
-            self._do_refresh()
-
-        if self.check_connected:
-            self.log.info('Total charge added %.2f', kwh)
-            self.log.info('Total charge held %.2f', self._soc_kwh)
-            self.log.info('SOC percentage %.0f', self.percent_charge())

--- a/mec/session.py
+++ b/mec/session.py
@@ -65,16 +65,18 @@ class SessionEngine():
         self._conf = conf
         self._py2 = None
         self._mt = None
+        self._jlr = None
         if 'leaf' in conf:
-
             if 'pycarwings_path' in conf:
                 sys.path.append(conf['pycarwings_path'])
             try:
                 self._py2 = __import__('pycarwings2')
             except ModuleNotFoundError:
                 self._py2 = None
-        elif 'tesla' in conf:
+        if 'tesla' in conf:
             self._mt = __import__('myTesla')
+        if 'jlr' in conf:
+            self._jlr = __import__('jlrpy')
 
     def new_session(self, have_car=False):
         """Return a new session"""
@@ -87,6 +89,8 @@ class SessionEngine():
                 return NullSession()
         elif self._mt:
             return TeslaSession(self._conf, self._mt)
+        elif self._jlr:
+            return jlrSession(self._conf, self._jlr)
         else:
             return NullSession()
 
@@ -349,3 +353,72 @@ class LeafSession(CommonSession):
             self.log.info('Total charge held %.2f', self._soc_kwh)
             self.log.info('SOC percentage %.0f', self.percent_charge())
 
+class jlrSession(CommonSession):
+    """Session counter"""
+
+    # Estimate of battery capacity, in terms of KwH charge to
+    # go from 0-100%.  Used for SOC calculations.
+    capacity = 85
+    charge_rate = 7800
+
+    def __init__(self, conf, jlr):
+        super().__init__(conf['jlr'])
+        jlr_conf = conf['jlr']
+
+        self._jlr = jlr.Connection(jlr_conf['username'], jlr_conf['password']).vehicles[0]
+        self._base_kwh = None
+
+
+    def _get_soc(self):
+        if not self._jlr:
+            return
+        raw = self._jlr.get_health_status()
+        self.log.debug(raw)
+        if 'Exception' in raw:
+            return
+        self._is_valid = True
+        current_soc = int(self._jlr.get_status('EV_STATE_OF_CHARGE'))
+        return current_soc
+
+    def _do_refresh(self):
+
+        new_percent = self._get_soc()
+
+        self.log.info('State of charge update %d%% %d%%',
+                      self.percent_charge(),
+                      new_percent)
+        # Calculate the observed capacity
+        added_percent = new_percent - self._initial_percent
+        added_kwh = self._soc_kwh - self._base_kwh
+        self.log.info('Percent %d %d %d', added_percent, new_percent, self._initial_percent)
+
+        if added_percent == 0:
+            return
+
+        new_cap = added_kwh * (100 / added_percent)
+        self.log.info('Capacity change from %.1f to %.1f after %.1f kwh',
+                      self.capacity,
+                      new_cap,
+                      added_kwh)
+
+    def update(self, kwh):
+
+        if self._is_valid is False:
+            return
+
+        if not self._base_kwh:
+            percent = self._get_soc()
+            if not percent:
+                return
+            self._initial_percent = percent
+            self._base_kwh = (self.capacity * self._initial_percent / 100) - kwh
+
+        self._soc_kwh = self._base_kwh + kwh
+
+        if self._refresh:
+            self._do_refresh()
+
+        if self.check_connected:
+            self.log.info('Total charge added %.2f', kwh)
+            self.log.info('Total charge held %.2f', self._soc_kwh)
+            self.log.info('SOC percentage %.0f', self.percent_charge())

--- a/mec/session.py
+++ b/mec/session.py
@@ -167,6 +167,7 @@ class TeslaSession(CommonSession):
 
     capacity = 70
     charge_rate = 7200
+    name = 'Tesla'
 
     def __init__(self, conf, mt):
         super().__init__(conf['tesla'])
@@ -239,6 +240,7 @@ class LeafSession(CommonSession):
     # go from 0-100%.  Used for SOC calculations.
     capacity = 26
     charge_rate = 6600
+    name = 'Leaf'
 
     def __init__(self, conf, py):
         super().__init__(conf['leaf'])
@@ -362,6 +364,7 @@ class jlrSession(CommonSession):
     # go from 0-100%.  Used for SOC calculations.
     capacity = 85
     charge_rate = 7800
+    name = 'Jaguar'
 
     def __init__(self, conf, jlr):
         super().__init__(conf['jlr'])

--- a/set_boost_charge.py
+++ b/set_boost_charge.py
@@ -113,7 +113,7 @@ def main():
                                       bdm=duration % 60)
             price = slots.get_price()
             total_price = charge_rate / 1000 * price
-            print('Estimated charge cost {:.1f} pence'.format(total_price))
+            print('Estimaged charge cost {:.1f} pence'.format(total_price))
 
         # Now clear any other boost timers.
         for zslot in SIDS:

--- a/set_boost_charge.py
+++ b/set_boost_charge.py
@@ -113,7 +113,7 @@ def main():
                                       bdm=duration % 60)
             price = slots.get_price()
             total_price = charge_rate / 1000 * price
-            print('Estimaged charge cost {:.1f} pence'.format(total_price))
+            print('Estimated charge cost {:.1f} pence'.format(total_price))
 
         # Now clear any other boost timers.
         for zslot in SIDS:


### PR DESCRIPTION
Hi @ashleypittman - hope you will consider including this somewhat clumsy attempt to include the Jaguar iPace in the supported vehicles for SoC. this way I can continue to use your excellent API without local tweaks for every update

I'm completely new to python and car control so copied from your Tesla work - tested working for the command "set_boost_charge.py --charge 20 --by-hour 7 --target-soc 80". Im sure there are better ways to do it. The Jaguar API draws on https://github.com/ardevd/jlrpy.git 

I have considered but not done any further work to support Volvo or Porsche but would like to, as well as get smarter about which car is connected to which Zappi at any point in time so different schedules can be made for each Zappi 