### PR TITLE
Update zp.py

### DIFF
--- a/mec/zp.py
+++ b/mec/zp.py
@@ -536,7 +536,7 @@ class MyEnergiHost:
             log.debug('Load took %.1f seconds', duration)
             data = json.loads(raw_data)
             if 'status' in data:
-                status = data['status']
+                status = int(data['status'])
                 if -status in E_CODES and data['statustext'] == '':
                     data['statustext'] = E_CODES[-status]
                     log.debug('request failed %s', suffix)
@@ -648,7 +648,7 @@ class MyEnergiHost:
             bdh = 8
             bdm = 0
 
-        res = self._load(suffix='cgi-boost-time-Z{}-{}-{:02}{}-{}{}-{}'.format(zid,
+        res = self._load(suffix='cgi-boost-time-Z{}-{}-{:02}{:02}-{}{:02}-{}'.format(zid,
                                                                                slot,
                                                                                bsh,
                                                                                bsm,
@@ -656,7 +656,7 @@ class MyEnergiHost:
                                                                                bdm,
                                                                                bdd))
         if 'status' in res and res['status'] != 0:
-            log.info('Error code is %s', E_CODES[-res['status']])
+            log.info('Error code is %s', E_CODES[-int(res['status'])])
             return
         self._show_timed_boost(res, slot=slot)
 


### PR DESCRIPTION
I'm not entirely sure why but my my nightly boost started failing - seems the formatting of the boost instruction to wipe needed some padding, and the status codes for errors needed to be an int or I received "bad operand type for unary - 'str'". Could just be me but thought I would contribute in the event others had similar