### PR TITLE
Update get_zappi_history.py

### DIFF
--- a/get_zappi_history.py
+++ b/get_zappi_history.py
@@ -105,7 +105,7 @@ def main():
 
         elif show_month:
             all_data = []
-            for dom in range(1, day.tm_mday + 1):
+            for dom in range(1, int(day.tm_mday) + 1):
                 print('Day {}'.format(dom))
                 day.tm_mday = dom
                 (headers, _, totals) = load_day(server_conn,


### PR DESCRIPTION
int(day.tm_mday)  to prevent from error if you are fetching data of a month before and have to set a dy manually